### PR TITLE
Remove state from AWS S3 bucket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,13 @@
 SHELL := /bin/bash
 
-AWS_REGION := ${AWS_REGION}
-AWS_ACCESS_KEY_ID := ${AWS_ACCESS_KEY_ID}
-AWS_SECRET_ACCESS_KEY := ${AWS_SECRET_ACCESS_KEY}
-BUCKET := ${BUCKET}
-
 CLOUDFLARE_EMAIL := ${CLOUDFLARE_EMAIL}
 CLOUDFLARE_TOKEN := ${CLOUDFLARE_TOKEN}
 CLOUDFLARE_ZONE := ${CLOUDFLARE_ZONE}
 WORKER_JS := ${WORKER_JS}
 
-
 CF_DIR=$(CURDIR)/terraform/cloudflare
 TERRAFORM_FLAGS :=
-CF_TERRAFORM_FLAGS =  -var "region=$(AWS_REGION)" \
-		-var "access_key=$(AWS_ACCESS_KEY_ID)" \
-		-var "secret_key=$(AWS_SECRET_ACCESS_KEY)" \
-		-var "bucket=$(BUCKET)" \
-		-var "cloudflare_email=$(CLOUDFLARE_EMAIL)" \
+CF_TERRAFORM_FLAGS = -var "cloudflare_email=$(CLOUDFLARE_EMAIL)" \
 		-var "cloudflare_email=$(CLOUDFLARE_EMAIL)" \
 		-var "cloudflare_token=$(CLOUDFLARE_TOKEN)" \
 		-var "zone=$(CLOUDFLARE_ZONE)" \
@@ -29,18 +19,11 @@ help:
 
 .PHONY: cf-init
 cf-init:
-	@:$(call check_defined, AWS_REGION, Amazon Region)
-	@:$(call check_defined, AWS_ACCESS_KEY_ID, Amazon Access Key ID)
-	@:$(call check_defined, AWS_SECRET_ACCESS_KEY, Amazon Secret Access Key)
-	@:$(call check_defined, BUCKET, s3 bucket name to store the terraform state)
 	@:$(call check_defined, CLOUDFLARE_EMAIL, Cloudflare email address)
 	@:$(call check_defined, CLOUDFLARE_TOKEN, Cloudflare api key)
 	@:$(call check_defined, CLOUDFLARE_ZONE, Cloudflare zone)
 	@:$(call check_defined, WORKER_JS, Worker JS file)
-	@cd $(CF_DIR) && terraform init \
-		-backend-config "bucket=$(BUCKET)" \
-		-backend-config "region=$(AWS_REGION)" \
-		$(CF_TERRAFORM_FLAGS)
+	@cd $(CF_DIR) && terraform init $(CF_TERRAFORM_FLAGS)		
 
 .PHONY: cf-import
 cf-import: cf-init ## Run terraform plan for Cloudflare worker.

--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,9 @@ check_defined = \
 				$(strip $(foreach 1,$1, \
 				$(call __check_defined,$1,$(strip $(value 2)))))
 __check_defined = \
-				  $(if $(value $1),, \
-				  $(error Undefined $1$(if $2, ($2))$(if $(value @), \
-				  required by target `$@')))
+				$(if $(value $1),, \
+					$(error Undefined $1$(if $2, ($2))$(if $(value @), \
+					required by target `$@')))
 
 .PHONY: update
 update: update-terraform ## Update terraform binary locally.

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ workflow "on push to master, deploy worker to Cloudflare" {
 action "worker deploy" {
   uses = "cpilsworth/cloudflare-worker-action@master"
   env = {
-    CLOUDFLARE_EMAIL = "you@example.com"
-    CLOUDFLARE_ZONE = "diffa.co.uk"
-    WORKER_JS = "bin/worker.js"
+    CLOUDFLARE_EMAIL = "you@example.com",
+    CLOUDFLARE_ZONE = "diffa.co.uk",
+    WORKER_JS = "bin/worker.js",
   }
-  secrets = ["CLOUDFLARE_TOKEN", "AWS_SECRET_ACCESS_KEY"]
+  secrets = [ "CLOUDFLARE_TOKEN" ]
 }
 ```
 


### PR DESCRIPTION
Removes references to AWS for terraform s3 bucket state.  Only one resource, simpler to import that state in on each run.